### PR TITLE
Replace deprecated \tl_set_from_file:Nnn with \file_get:nnN

### DIFF
--- a/leadsheets.library.external.code.tex
+++ b/leadsheets.library.external.code.tex
@@ -122,9 +122,9 @@
 % and \LeadsheetEndSurvive
 \cs_new_protected:Npn \leadsheets_include_external_file:nn #1#2
   {
-    \tl_set_from_file:Nnn \l__leadsheets_tmpa_tl
+    \file_get:nnN { #1 \tl_if_blank:nF {#2} {.} #2 }
       {}
-      { #1 \tl_if_blank:nF {#2} {.} #2 }
+      \l__leadsheets_tmpa_tl
     \cs_set:Npn \LeadsheetSurvive ##1 \LeadsheetEndSurvive ##2 \q_stop
       { ##1 \__leadsheets_extract_survival:ww ##2 \q_stop }
     \__leadsheets_include_external_file_aux:V \l__leadsheets_tmpa_tl


### PR DESCRIPTION
Hi,

I recently ran into a problem using the external library, more specifically using the command `\includeleadsheet{file}` without the `*`. Compiling my document failed with the error:
```
LaTeX3 Error: Use \file_get:nnN not \tl_set_from_file:Nnn deprecated on
(LaTeX3)        2021-01-01. For 6 months after that date one can restore a
(LaTeX3)        deprecated command by loading the expl3 package with the
(LaTeX3)        option 'undo-recent-deprecations'.
```
I got this error using `leadsheets version 0.6` from MikTeX both under Ubuntu 20.04 and Windows. I compiled using latexmk/pdflatex.

For fixing this problem I followed this answer on stackexchange: https://tex.stackexchange.com/a/474897. Testing it, my document compiled fine and the output looked as expected.

However, this is my first time programming for LaTeX, so I am not sure if this code might not cause other problems or unexpected behaviour. Still, I hope that the proposed fix is sufficient.

Thanks and best regards,
Daniel

P.S.: This is my first time contributing to someone else's work on Github, so please let me know if I handled anything incorrectly :) Also, would this kind of problem better be discussed in an Issue?