### PR TITLE
Add skipchord command

### DIFF
--- a/leadsheets.library.chords.code.tex
+++ b/leadsheets.library.chords.code.tex
@@ -253,6 +253,16 @@
 \NewDocumentCommand \recallchord {st-}
   { \leadsheets_recall_chord:nn {#1} {#2} }
 
+\cs_new_protected:Npn \leadsheets_skip_chord:nn #1#2
+  {
+    \seq_pop_left:NNF \g__leadsheets_chords_sequences_seq
+      \l__leadsheets_tmpa_tl
+      { \msg_error:nnV {leadsheets} {no-chords} \l_leadsheets_verse_type_tl }
+  }
+
+\NewDocumentCommand \skipchord {st-}
+  { \leadsheets_skip_chord:nn {#1} {#2} }
+
 \NewDocumentCommand \getorprintchord {}
   {
     \leadsheets_if_recall_chords:TF

--- a/leadsheets.library.chords.code.tex
+++ b/leadsheets.library.chords.code.tex
@@ -263,6 +263,13 @@
 \NewDocumentCommand \skipchord {st-}
   { \leadsheets_skip_chord:nn {#1} {#2} }
 
+\NewDocumentCommand \skipchordifrecalling {}
+  {
+    \leadsheets_if_recall_chords:TF
+      { \skipchord }
+      { \empty }
+  }
+
 \NewDocumentCommand \getorprintchord {}
   {
     \leadsheets_if_recall_chords:TF


### PR DESCRIPTION
This is a feature I need for a project and think would be useful in general.

Added \skipchord command that skips the next remembered chord. This allows for more flexibility when remembering chords (in addition to adding chords that aren't the remembered ones, you can now also remove chords that have been remembered for one occurence).